### PR TITLE
Update README.md regarding PRIMA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 Optimization software by Professor M. J. D. Powell
 
 Please see the wiki for details and download instructions.
+
+Please note that the Fortran-77 implementation of Powell's solvers archived in this repository is not maintained anymore. For the modernized reference implementation, refer to [PRIMA](http://www.libprima.net), which also offers C, Python, MATLAB, and Julia interfaces for these solvers.


### PR DESCRIPTION
Add a note to inform the users that the Fortran-77 implementation of Powell's solvers is not maintained anymore and suggest PRIMA for the modernized reference implementation.